### PR TITLE
Set privacy.html as index.html for GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Privacy Policy - Chrome AI Scraper</title>
+  <link rel="stylesheet" href="privacy.css">
+</head>
+<body>
+  <h1>Privacy Policy</h1>
+  <p><strong>Effective Date:</strong> May 29, 2025</p>
+
+  <p>This privacy policy applies to the <strong>Chrome AI Scraper</strong> extension (the "Extension") and explains how your data is handled when you use it. We are committed to protecting your privacy and ensuring transparency.</p>
+
+  <h2>Overview</h2>
+  <p>This Extension is a lightweight content summarizer that runs primarily in your browser. It processes visible webpage content using Google’s <strong>Gemini API</strong> (a cloud-based AI service) to generate summaries. It does <strong>not collect, store, or sell</strong> any personally identifiable information (PII).</p>
+
+  <h2>1. Information Collected</h2>
+  <p>The Extension does not collect user-identifiable data. However, to provide AI-powered summaries, it sends selected webpage content (only the visible text content of the active tab) to Google's Gemini API for processing. This is done <strong>only after the user manually activates the extension</strong>.</p>
+
+  <h2>2. Use of Gemini API</h2>
+  <p>Gemini API is provided by Google and subject to its <a href="https://policies.google.com/privacy" target="_blank">Privacy Policy</a> and <a href="https://cloud.google.com/terms" target="_blank">Cloud Terms of Service</a>. The Extension sends:</p>
+  <ul>
+    <li>Only visible text content from the current page (e.g., article body, paragraphs)</li>
+    <li>No user credentials, cookies, or sensitive form data are transmitted</li>
+  </ul>
+  <p><strong>We do not have access to or store any of the data processed by Gemini.</strong> All requests are ephemeral and stateless.</p>
+
+  <h2>3. Data We Do Not Collect</h2>
+  <p>The Extension does <strong>not</strong> collect or transmit any of the following:</p>
+  <ul>
+    <li>Names, emails, phone numbers, or personal identifiers</li>
+    <li>IP addresses or geolocation</li>
+    <li>Cookies or tokens</li>
+    <li>User browsing history or cross-tab data</li>
+    <li>Form inputs or login credentials</li>
+  </ul>
+
+  <h2>4. When Content Is Processed</h2>
+  <p>Content is only processed when the user clicks the action button. There is no background or silent scraping. No scheduled or automated requests are made. The request to Gemini is initiated strictly in response to a user command.</p>
+
+  <h2>5. Real-Time and Stateless Design</h2>
+  <p>The Extension is designed to be stateless. It does not:</p>
+  <ul>
+    <li>Store any data on the user’s device (no localStorage, no IndexedDB)</li>
+    <li>Save summaries or inputs</li>
+    <li>Use cookies or tracking pixels</li>
+  </ul>
+
+  <h2>6. No Third-Party Sharing</h2>
+  <p>Except for the Gemini API request for summarization, the Extension does not transmit any information to third parties, advertising networks, or analytics services.</p>
+
+  <h2>7. Permissions</h2>
+  <p>The Extension uses only the <code>"activeTab"</code> permission, which allows access to the current tab's visible content after user interaction. It does not have access to other tabs, browser history, or personal data.</p>
+
+  <h2>8. Security</h2>
+  <p>The data is transmitted securely over HTTPS when sent to the Gemini API. No data is stored or logged by the Extension developer.</p>
+
+  <h2>9. Compliance</h2>
+  <p>This Extension adheres to all applicable Chrome Web Store policies, including the <a href="https://developer.chrome.com/docs/webstore/program_policies/" target="_blank">Developer Program Policies</a> and Google's <a href="https://policies.google.com/privacy" target="_blank">Privacy Policy</a>.</p>
+
+  <h2>10. Changes</h2>
+  <p>This policy may be updated in response to changes in the Extension or Chrome Store requirements. Any updates will be reflected here.</p>
+
+  <h2>11. Contact</h2>
+  <p>If you have questions or concerns, please reach out through our <a href="https://github.com/yourusername/chrome-ai-scraper" target="_blank">GitHub repository</a>.</p>
+
+  <p><strong>By using this Extension, you consent to this Privacy Policy and agree to the Gemini API terms as applicable.</strong></p>
+</body>
+</html>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive Privacy Policy page for the Chrome AI Scraper browser extension, outlining data handling practices, security measures, permissions, and user rights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->